### PR TITLE
Implement crude pretty-printing

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,11 +7,8 @@ import testSuites from './test/tests.json';
 import { evalString, deftests, clearTests } from "./src/interpreter"
 
 let editorState = EditorState.create({
-  doc: `((fn ([[exponent bit]]
-       (if (= "1" bit)
-         (Math/pow 2 exponent)
-         0)))
- [0 "1"])`,
+  doc: `[1 2 
+    3]`,
   extensions: [basicSetup, clojure()]
 })
 

--- a/main.js
+++ b/main.js
@@ -167,7 +167,7 @@ function testExercisesUntilFail() {
 }
 
 //testSolution(randExercise())
-//testSolution("two_fer")
+testSolution("roman")
 //loadExercise("all_your_base")
 //testExercisesUntilFail()
 //testExercises()

--- a/main.js
+++ b/main.js
@@ -7,8 +7,7 @@ import testSuites from './test/tests.json';
 import { evalString, deftests, clearTests } from "./src/interpreter"
 
 let editorState = EditorState.create({
-  doc: `[1 2 
-    3]`,
+  doc: `(+ (do (print "hi") (+ 1 1)) 1)`,
   extensions: [basicSetup, clojure()]
 })
 
@@ -167,7 +166,7 @@ function testExercisesUntilFail() {
 }
 
 //testSolution(randExercise())
-testSolution("roman")
+//testSolution("veitch")
 //loadExercise("all_your_base")
 //testExercisesUntilFail()
 //testExercises()

--- a/scratch.clj
+++ b/scratch.clj
@@ -409,3 +409,31 @@
         (str (if (neg? n) "minus ") full-str)))))
 
 (number 1)
+
+
+{:a 1 :b 2 :c 3 :d 4}
+
+(clojure.pprint/pprint
+ (into {} (for [x (range 11)
+                y (range 11)]
+            [x y])))
+
+(def I #{#{'a 'B 'C 'd}
+         #{'A 'b 'c 'd}
+         #{'A 'b 'c 'D}
+         #{'A 'b 'C 'd}
+         #{'A 'b 'C 'D}
+         #{'A 'B 'c 'd}
+         #{'A 'B 'c 'D}
+         #{'A 'B 'C 'd}})
+
+#{#{'a 'B 'C 'd}
+  #{'A 'b 'c 'd}
+  #{'A 'b 'c 'D}
+  #{'A 'b 'C 'd}
+  #{'A 'b 'C 'D}
+  #{'A 'B 'c 'd}
+  #{'A 'B 'c 'D}
+  #{'A 'B 'C 'd}}
+
+(print ['a :b "\n" \space "c"])

--- a/src/clj/pprint.clj
+++ b/src/clj/pprint.clj
@@ -1,5 +1,7 @@
 (ns pprint {:clj-kondo/ignore true})
 
+;; adapted from clojure.pprint
+
 (def *print-pretty* true)
 (def *print-pprint-dispatch* nil)
 (def *print-right-margin* 72)
@@ -13,6 +15,32 @@
 (def *current-level* 0)
 (def *current-length* nil)
 (def format-simple-number)
+(def orig-pr pr)
+
+(defn- pr-with-base [x]
+  (if-let [s (format-simple-number x)]
+    (print s)
+    (orig-pr x)))
+
+(def write-option-table
+  {;:array            *print-array*
+   :base             '*print-base*,
+      ;;:case             *print-case*,
+   :circle           '*print-circle*,
+      ;;:escape           *print-escape*,
+      ;;:gensym           *print-gensym*,
+   :length           '*print-length*,
+   :level            '*print-level*,
+   :lines            '*print-lines*,
+   :miser-width      '*print-miser-width*,
+   :dispatch         '*print-pprint-dispatch*,
+   :pretty           '*print-pretty*,
+   :radix            '*print-radix*,
+   :readably         '*print-readably*,
+   :right-margin     '*print-right-margin*,
+   :suppress-namespaces '*print-suppress-namespaces*})
+
+;; basic MAL pretty printer
 
 (defn spaces- [indent]
      (if (> indent 0)

--- a/src/clj/pprint.clj
+++ b/src/clj/pprint.clj
@@ -1,0 +1,37 @@
+(ns pprint {:clj-kondo/ignore true})
+
+(defn spaces- [indent]
+     (if (> indent 0)
+       (str " " (spaces- (- indent 1)))
+       ""))
+
+(defn pp-seq- [obj indent]
+     (let* [xindent (+ 1 indent)]
+           (apply str (pp- (first obj) 0)
+                  (map (fn [x] (str "\n" (spaces- xindent)
+                                     (pp- x xindent)))
+                       (rest obj)))))
+
+(defn pp-map- [obj indent]
+     (let* [ks (keys obj)
+            kindent (+ 1 indent)
+            kwidth (count (seq (str (first ks))))
+            vindent (+ 1 (+ kwidth kindent))]
+           (apply str (pp- (first ks) 0)
+                  " "
+                  (pp- (get obj (first ks)) 0)
+                  (map (fn [k] (str "\n" (spaces- kindent)
+                                     (pp- k kindent)
+                                     " "
+                                     (pp- (get obj k) vindent)))
+                       (rest (keys obj))))))
+
+(defn pp- [obj indent]
+     (cond
+       (list? obj)   (str "(" (pp-seq- obj indent) ")")
+       (vector? obj) (str "[" (pp-seq- obj indent) "]")
+       (map? obj)    (str "{" (pp-map- obj indent) "}")
+       :else         (pr-str obj)))
+
+(defn pprint [obj]
+  (pp- obj 0))

--- a/src/clj/pprint.clj
+++ b/src/clj/pprint.clj
@@ -1,5 +1,19 @@
 (ns pprint {:clj-kondo/ignore true})
 
+(def *print-pretty* true)
+(def *print-pprint-dispatch* nil)
+(def *print-right-margin* 72)
+(def *print-miser-width* 40)
+(def *print-lines* nil)
+(def *print-circle* nil)
+(def *print-shared* nil)
+(def *print-suppress-namespaces* nil)
+(def *print-radix* nil)
+(def *print-base* 10)
+(def *current-level* 0)
+(def *current-length* nil)
+(def format-simple-number)
+
 (defn spaces- [indent]
      (if (> indent 0)
        (str " " (spaces- (- indent 1)))
@@ -30,6 +44,7 @@
      (cond
        (list? obj)   (str "(" (pp-seq- obj indent) ")")
        (vector? obj) (str "[" (pp-seq- obj indent) "]")
+       (set? obj) (str "#{" (pp-seq- obj indent) "}")
        (map? obj)    (str "{" (pp-map- obj indent) "}")
        :else         (pr-str obj)))
 

--- a/src/core.js
+++ b/src/core.js
@@ -53,7 +53,7 @@ function str() {
 
 function prn() {
     _println.apply({}, Array.prototype.map.call(arguments, function (exp) {
-        appendBuffer(exp)
+        appendBuffer(exp + "\n")
         return _pr_str(exp, true);
     }));
 }

--- a/src/core.js
+++ b/src/core.js
@@ -434,7 +434,10 @@ function int(x) {
 }
 
 function double(x) {
-    return x.valueOf()
+    if (types._ratio_Q(x)) {
+        return x.n / x.d
+    }
+    return x
 }
 
 function char(int) {

--- a/src/core.js
+++ b/src/core.js
@@ -4,6 +4,28 @@ import * as types from './types.js'
 import { repl_env, evalString } from './interpreter.js';
 import zip from './clj/zip.clj?raw'
 
+export var out_buffer = ""
+
+export function appendBuffer(s) {
+    out_buffer = out_buffer + s
+}
+
+export function clearBuffer() {
+    out_buffer = ""
+}
+
+function _print(s) {
+    appendBuffer(s)
+}
+
+function _pr(s) {
+    if (arguments.length > 1) {
+        appendBuffer(Array.from(arguments).join(' '))
+    } else {
+        appendBuffer(s)
+    }
+}
+
 // Errors/Exceptions
 function mal_throw(exc) { throw new Error(exc); }
 
@@ -31,12 +53,14 @@ function str() {
 
 function prn() {
     _println.apply({}, Array.prototype.map.call(arguments, function (exp) {
+        appendBuffer(exp)
         return _pr_str(exp, true);
     }));
 }
 
 function println() {
     _println.apply({}, Array.prototype.map.call(arguments, function (exp) {
+        appendBuffer(exp + "\n")
         return _pr_str(exp, false);
     }));
 }
@@ -716,7 +740,7 @@ function sort(x) {
 }
 
 function makeComparator(f) {
-    return function(x, y) {
+    return function (x, y) {
         let r = f(x, y)
         if (types._number_Q(r)) {
             return r
@@ -895,15 +919,17 @@ function map_indexed(f, coll) {
     let ret = [];
     let i = 0;
     for (const x of coll) {
-      ret.push(f(i, x));
-      i++;
+        ret.push(f(i, x));
+        i++;
     }
     return ret;
-  }
+}
 
 // types.ns is namespace of type functions
 export var ns = {
     'env': printEnv,
+    'print': _print,
+    'pr': _pr,
     'spit-json': spit_json,
     'LazySeq': LazySeq,
     'require': require,

--- a/src/core.js
+++ b/src/core.js
@@ -51,11 +51,12 @@ function str() {
     }).join("");
 }
 
-function prn() {
-    _println.apply({}, Array.prototype.map.call(arguments, function (exp) {
-        appendBuffer(exp + "\n")
-        return _pr_str(exp, true);
-    }));
+function prn(s) {
+    if (arguments.length > 1) {
+        appendBuffer(Array.from(arguments).join(' ') + "\n")
+    } else {
+        appendBuffer(s + "\n")
+    }
 }
 
 function println() {

--- a/src/eval-region.js
+++ b/src/eval-region.js
@@ -2,6 +2,7 @@ import { Prec } from '@codemirror/state'
 import { keymap } from '@codemirror/view'
 import { syntaxTree } from "@codemirror/language"
 import { repp } from "./interpreter"
+import {out_buffer, appendBuffer, clearBuffer} from './core'
 
 const up = (node) => node.parent;
 const isTopType = (nodeType) => nodeType.isTop
@@ -55,7 +56,7 @@ export var testCodeBeforeEval = ""
 var posBeforeEval = 0
 var testPosBeforeEval = 0
 
-const updateEditor = (view, text, pos) => {
+export const updateEditor = (view, text, pos) => {
     var parent = view.dom.parentElement.id
     var doc = view.state.doc.toString()
     const end = doc.length
@@ -121,9 +122,10 @@ export const evalAtCursor = (view) => {
         var codeBeforeCursor = codeBeforeEval.slice(0, posBeforeEval)
         var codeAfterCursor = codeBeforeEval.slice(posBeforeEval, codeBeforeEval.length)
         evalResult = tryEval(cursorNodeString(view.state))
-        var codeWithResult = codeBeforeCursor + " =>" + "\n" + evalResult + " " + codeAfterCursor
+        var codeWithResult = codeBeforeCursor + " =>" + "\n" + out_buffer + evalResult + " " + codeAfterCursor
         updateEditor(view, codeWithResult, posBeforeEval)
         view.dispatch({ selection: { anchor: posBeforeEval, head: posBeforeEval } })
+        clearBuffer()
         return true
     }
     if (parent === 'test') {
@@ -132,9 +134,10 @@ export const evalAtCursor = (view) => {
         var codeBeforeCursor = codeBeforeEval.slice(0, posBeforeEval)
         var codeAfterCursor = codeBeforeEval.slice(posBeforeEval, codeBeforeEval.length)
         evalResult = tryEval(cursorNodeString(view.state))
-        var codeWithResult = codeBeforeCursor + " =>" + "\n" + evalResult + " " + codeAfterCursor
+        var codeWithResult = codeBeforeCursor + " =>" + "\n" + out_buffer + evalResult + " " + codeAfterCursor
         updateEditor(view, codeWithResult, posBeforeEval)
         view.dispatch({ selection: { anchor: posBeforeEval, head: posBeforeEval } })
+        clearBuffer()
         return true
     }
 }
@@ -145,14 +148,15 @@ export const evalTopLevel = (view) => {
     const doc = view.state.doc.toString()
     //console.log("doc:", doc)
     posBeforeEval = view.state.selection.main.head
-    console.log("set posBeforeEval to", posBeforeEval)
+    //console.log("set posBeforeEval to", posBeforeEval)
     codeBeforeEval = doc
     const codeBeforeFormEnd = codeBeforeEval.slice(0, posAtFormEnd)
     const codeAfterFormEnd = codeBeforeEval.slice(posAtFormEnd, codeBeforeEval.length)
     evalResult = tryEval(topLevelString(view.state))
-    const codeWithResult = codeBeforeFormEnd + "\n" + "=> " + "\n" + evalResult + " " + codeAfterFormEnd
-    console.log("setting cursor position to", posBeforeEval)
+    const codeWithResult = codeBeforeFormEnd + "\n" + "=> " + "\n" + out_buffer + evalResult + " " + codeAfterFormEnd
+    //console.log("setting cursor position to", posBeforeEval)
     updateEditor(view, codeWithResult, posBeforeEval)
+    clearBuffer()
     return true
 }
 
@@ -162,8 +166,9 @@ export const evalCell = (view) => {
     //console.log("doc:", doc)
     posBeforeEval = view.state.selection.main.head
     evalResult = tryEval("(do " + view.state.doc.text.join(" ") + ")")
-    const codeWithResult = doc + "\n" + "=> " + "\n" + evalResult
+    const codeWithResult = doc + "\n" + "=> " + "\n" + out_buffer + evalResult
     updateEditor(view, codeWithResult, posBeforeEval)
+    clearBuffer()
     return true
 }
 

--- a/src/eval-region.js
+++ b/src/eval-region.js
@@ -1,7 +1,7 @@
 import {Prec} from '@codemirror/state'
 import {keymap} from '@codemirror/view'
 import {syntaxTree} from "@codemirror/language"
-import {evalString} from "./interpreter"
+import {repp} from "./interpreter"
 
 const up = (node) => node.parent;
 const isTopType = (nodeType) => nodeType.isTop
@@ -72,9 +72,10 @@ const updateEditor = (view, text, pos) => {
 }
 
 export function tryEval(s) {
-   // console.log("Trying to eval", s)
+   //console.log("Trying to eval", s)
     try {
-        return evalString(s)
+        //console.log("evalPretty:", evalPretty(s))
+        return repp(s)
       } catch (err) {
         console.log(err)
         return "\nError: " + err.message
@@ -109,7 +110,7 @@ export const evalAtCursor = (view) => {
     const codeBeforeCursor = codeBeforeEval.slice(0, posBeforeEval)
     const codeAfterCursor = codeBeforeEval.slice(posBeforeEval, codeBeforeEval.length)
     evalResult = tryEval(cursorNodeString(view.state))
-    const codeWithResult = codeBeforeCursor + " => " + evalResult + " " + codeAfterCursor
+    const codeWithResult = codeBeforeCursor + " =>"+ "\n" + evalResult + " " + codeAfterCursor
     updateEditor(view, codeWithResult, posBeforeEval)
     view.dispatch({selection: {anchor: posBeforeEval, head: posBeforeEval}})
 
@@ -126,7 +127,7 @@ export const evalTopLevel = (view) => {
     const codeBeforeFormEnd = codeBeforeEval.slice(0, posAtFormEnd)
     const codeAfterFormEnd = codeBeforeEval.slice(posAtFormEnd, codeBeforeEval.length)
     evalResult = tryEval(topLevelString(view.state))
-    const codeWithResult = codeBeforeFormEnd + "\n" + "=> " + evalResult + " " + codeAfterFormEnd
+    const codeWithResult = codeBeforeFormEnd + "\n" + "=> " + "\n" + evalResult + " " + codeAfterFormEnd
     updateEditor(view, codeWithResult, posBeforeEval)
     return true
 }
@@ -137,7 +138,7 @@ export const evalCell = (view) => {
     //console.log("doc:", doc)
     posBeforeEval = view.state.selection.main.head
     evalResult = tryEval("(do " + view.state.doc.text.join(" ") + ")")
-    const codeWithResult = doc + "\n" + "=> " + evalResult
+    const codeWithResult = doc + "\n" + "=> "+ "\n" + evalResult
     updateEditor(view, codeWithResult, posBeforeEval)
     return true
 }

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -4,6 +4,7 @@ import { Env } from './env.js'
 import * as types from './types.js'
 import * as core from './core.js'
 import core_clj from './clj/core.clj?raw'
+import pprint from './clj/pprint.clj?raw'
 
 // read
 export function READ(str) {
@@ -272,3 +273,8 @@ repl_env.set(types._symbol('*ARGV*'), []);
 
 // load core.clj
 evalString("(do " + core_clj + ")")
+evalString("(do " + pprint + ")")
+
+export const repp = function (str) {
+    return EVAL(READ("(pprint " + "(do " + str + "))"), repl_env)
+};


### PR DESCRIPTION
Uses the printer from the MAL project. Started porting things from clojure.pprint to learn how to make it better.

This led me to implement a print buffer, which is prepended to the eval output, so now we can do stuff like this:

```clojure
(+ (do (pr "hello" "kitty") (+ 1 1)) 1)
=> 
hello kitty3 
```

The print buffer is used by `pr`, `prn`, `print` and `println`, so their arguments are rendered along with the evaluation output without affecting the return value.

The biggest drawback of this pretty printer is that it always prints 1 item per line for seqs, and 2 for maps. But this is an improvement over the previous behavior which had the opposite problem, where the output was all on one line which pretty much always required horizontally scrolling the editor to see the result.